### PR TITLE
Quickfix the position to get godot editor top buttons

### DIFF
--- a/addons/fabimakesgames.embed_game/embed_game.gd
+++ b/addons/fabimakesgames.embed_game/embed_game.gd
@@ -246,9 +246,15 @@ func set_window_mode(mode: DisplayServer.WindowMode):
 func get_top_buttons() -> Array[Node]:
 	var cont := Control.new()
 	add_control_to_container(CustomControlContainer.CONTAINER_TOOLBAR, cont)
-	var btns := cont.get_parent().get_child(2).get_children()
+	var btns := cont.get_parent().get_child(get_top_buttons_position()).get_children()
 	remove_control_from_container(CustomControlContainer.CONTAINER_TOOLBAR, cont)
 	return btns
+	
+func get_top_buttons_position() -> int:
+	var top_buttons_position = 2
+	if OS.get_name() == "macOS":
+		top_buttons_position = 3
+	return top_buttons_position
 	
 func get_main_screen_rect() -> Rect2i:
 	var main_screen : = EditorInterface.get_editor_main_screen()


### PR DESCRIPTION
### Description

This pull request addresses an issue on macOS where the window "open/resize/close" buttons are positioned on the left side, causing a modification in the order of the Godot top view buttons (like the "2D/3D/Etc" buttons). The fix ensures that the position of these top buttons is adapted specifically for macOS.

### Changes

Added a function to get the position of the top buttons that takes into account the macOS operating system.
Integrated this function into the `get_top_buttons()` function to adjust the button positions appropriately.

### How to Test

- Open the Godot editor on a macOS system.
- Verify that there are no errors such as:
`res://addons/fabimakesgames.embed_game/embed_game.gd:122 - Invalid assignment of property or key 'shortcut' with value of type 'Shortcut' on a base object of type 'Nil'.` or 
`res://addons/fabimakesgames.embed_game/embed_game.gd:140 - Invalid access to property or key 'button_pressed' on a base object of type 'Nil'.`
- Check if the plugin works correctly when toggling the Embed top button and running your game.
- Test the plugin on other operating systems (e.g., Windows) to ensure the changes do not affect the way the positions of the top buttons are determined.

### Additional Notes

This fix specifically targets macOS and is fully written in GDScript.